### PR TITLE
Fixed bad terminator in literals.c fields

### DIFF
--- a/src/literals.c
+++ b/src/literals.c
@@ -1,11 +1,11 @@
 //
 // Created by istoffa on 7/28/17.
 //
-
+#include <stdlib.h>
 #include "literals.h"
 
 /* IANA protocol list subset*/
-const struct nff_literal_s nff_proto_id_map[]={
+struct nff_literal_s nff_proto_id_map[]={
     { "ICMP",	1 },
     { "IGMP",	2 },
     { "IPv4",	4 },
@@ -25,11 +25,11 @@ const struct nff_literal_s nff_proto_id_map[]={
     { "SCTP",	132 },
     { "UDPLite",	136 },
     // terminator
-    { "", 	0U }
+    { NULL, 	0U }
 };
 
 /* IANA assigned port names subset */
-const struct nff_literal_s nff_port_map[]={
+struct nff_literal_s nff_port_map[]={
     { "tcpmux",	1 },
     { "echo",	7 },
     { "discard",	9 },
@@ -51,15 +51,15 @@ const struct nff_literal_s nff_port_map[]={
     { "http",	80 },
     { "https",	443 },
     // terminator
-    { "", 	0U }
+    { NULL, 	0U }
 };
 
-const struct nff_literal_s * nff_get_protocol_map()
+struct nff_literal_s * nff_get_protocol_map()
 {
     return &nff_proto_id_map[0];
 }
 
-const struct nff_literal_s * nff_get_port_map()
+struct nff_literal_s * nff_get_port_map()
 {
     return &nff_port_map[0];
 }

--- a/src/literals.h
+++ b/src/literals.h
@@ -13,7 +13,7 @@ typedef struct nff_literal_s {
 }nff_literal_t;
 
 
-const struct nff_literal_s * nff_get_protocol_map();
-const struct nff_literal_s * nff_get_port_map();
+struct nff_literal_s * nff_get_protocol_map();
+struct nff_literal_s * nff_get_port_map();
 
 #endif //IPFIXCOL_RVALUES_H

--- a/src/lnf_filter.c
+++ b/src/lnf_filter.c
@@ -185,7 +185,7 @@ ff_error_t lnf_rval_map_func(ff_t *filter, const char *valstr, ff_type_t type, f
     // Universal processing for literals
     nff_literal_t *item = NULL;
 
-    for (int x = 0; dict[x].name != ""; x++) {
+    for (int x = 0; dict[x].name != NULL; x++) {
         if (!strcasecmp(valstr, dict[x].name)) {
             item = &dict[x];
             break;


### PR DESCRIPTION
Fix of terminator,
also x != "" does not really makes sense => two pointers comparation. -> segfault if you try to compile nonexistent literal