### PR TITLE
Fixed a few build issues

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,7 +1,7 @@
 
 AM_CFLAGS = -I$(top_srcdir)/include 
 
-EXTRA_DIST = cpucores.h flist.h output.h progress.h output_line.h output_nfdump.h 
+EXTRA_DIST = cpucores.h flist.h output.h progress.h output_line.h output_nfdump.h output_ringbuf.h
 
 if LNF_THREADS
 bin_PROGRAMS = nfdumpp

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CC_STDC
 
-#LIBS="$LIBS -lrt"
+LIBS="$LIBS -lrt"
 
 dnl get the flags
 CFLAGS="${CFLAGS=}"

--- a/libnf.spec.in
+++ b/libnf.spec.in
@@ -1,7 +1,7 @@
 Name: 		libnf
 Version: 	@VERSION@
 #Release:	1%{?dist}
-Release:	1
+Release:	2
 Summary:	Library providing C API for processing nfdump files
 
 Group:		Networking/Tools
@@ -10,7 +10,7 @@ URL:		http://libnf.net
 Source0:	http://libnf.net/packages/%{name}-%{version}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
-#BuildRequires:	
+BuildRequires: bzip2-devel
 Requires: bzip2-libs
 
 


### PR DESCRIPTION
This commit should fix build issues on Centos 7 and Fedora systems. After these changes, `make rpm` works and even Fedora COPR build accepts the src rpm and build properly.