### PR TITLE
Fix regex incompatibility with recent versions of perl

### DIFF
--- a/check_items_map.pl
+++ b/check_items_map.pl
@@ -85,7 +85,7 @@ sub get_master_record() {
 	while (<F1>) {
 		chomp;
 
-		if (/typedef struct master_record_s {/) {
+		if (/typedef struct master_record_s \{/) {
 			$in_master = 1;
 			next;
 


### PR DESCRIPTION
Perl v5.26.1 produced following error:
Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/typedef struct master_record_s { <-- HERE / at ./check_items_map.pl line 88.