### PR TITLE
Update libnf-devel dependency requirements

### DIFF
--- a/libnf.spec.in
+++ b/libnf.spec.in
@@ -21,7 +21,7 @@ See http://libnf.net for more information.
 %package devel
 Summary:	Libraries and header files for the libnf.net library
 Group:		Development/Libraries
-Requires:	%{name} 
+Requires:	%{name} bzip2-devel
 
 
 %description devel


### PR DESCRIPTION
Add dependency to bzip2-devel in libnf-devel package. This is needed so that software using libnf library can meet the necessary dependency requirements without having to manually install bzip2-devel